### PR TITLE
feat: implement plugin to always release as a certain type

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,14 @@
+const SUPPORTED_TYPES = [
+  'major', 'premajor', 'minor', 'preminor', 'patch', 'prepatch', 'prerelease'
+]
+
+module.exports = function (pluginConfig, _, cb) {
+  const {type} = pluginConfig
+
+  if (!SUPPORTED_TYPES.includes(type)) {
+    cb(new Error(`Unsupported type: ${type}`), type)
+    return
+  }
+
+  cb(null, type)
+}

--- a/index.spec.js
+++ b/index.spec.js
@@ -1,0 +1,16 @@
+const analyzeCommits = require('./')
+
+describe('semantic-release-always-release-as-x', () => {
+  it('accepts the release type as configuration', () => {
+    analyzeCommits({type: 'minor'}, {}, (err, type) => {
+      expect(err).toBe(null)
+      expect(type).toBe('minor')
+    })
+  })
+
+  it('throws an error if the type is not a supported type', () => {
+    analyzeCommits({type: 'taylor swift'}, {}, (err, type) => {
+      expect(err.message).toBe('Unsupported type: taylor swift')
+    })
+  })
+})

--- a/package.json
+++ b/package.json
@@ -10,7 +10,15 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "commitmsg": "validate-commit-msg",
-    "precommit": "npm run lint && npm t"
+    "precommit": "npm run lint && npm t",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+  },
+  "standard": {
+    "globals": [
+      "expect",
+      "describe",
+      "it"
+    ]
   },
   "devDependencies": {
     "husky": "^0.13.3",


### PR DESCRIPTION
Example package.json configuration

```
"release": {
  "analyzeCommits": {
    "path": "semantic-release-always-release-as-x",
    "type": "minor"
  }
}
```